### PR TITLE
Initial S3 public-read experiment commit

### DIFF
--- a/src/lambda/S3PublicRead_Slingr.py
+++ b/src/lambda/S3PublicRead_Slingr.py
@@ -1,0 +1,22 @@
+import boto3
+from botocore.exceptions import ClientError
+import random
+import json
+import time
+
+s3 = boto3.client('s3')
+
+def lambda_handler(event, context):
+    bucket_name = 'publicReadable'
+
+    # Create benign S3 bucket
+    create_response = s3.create_bucket(ACL='private', Bucket=bucket_name, CreateBucketConfiguration={'LocationConstraint': 'us-east-2'})
+    print('create_response = ', create_response)
+
+    # Make benign S3 bucket publicly visible
+    config_response = s3.put_bucket_acl(Bucket=bucket_name, ACL='public-read-write')
+    print('config_response = ', config_response)
+
+    # Delete unnecessary S3 resource - change detection should have occurred by now
+    delete_response = s3.delete_bucket(Bucket=bucket_name)
+    print('delete_response = ', delete_response)


### PR DESCRIPTION
Slingr functionality for S3 public-read permissions experiment.

A common cause of breach for companies in the cloud has been simply misconfigurations around their data storage mechanisms (often S3). Should their security controls not detect insecure settings as soon as a bucket becomes public-readable? This experiment is designed to test such a control. 

The initial commit has the "slingr" functionality included. This is simply the experiment action itself (managing the lifecycle of the experimental S3 bucket). Any "generatr" or "trackr" functionality can be encompassed in a separate PR. This experiment may be unique in that the resource being misconfigured is controlled within the context of the experiment (we manage the entire lifecycle), so any Generatr function will need to be adjusted accordingly. 

Thanks for reviewing!
-Sam @sbroden and Grayson @egb2016 